### PR TITLE
feat/03-4409: Implementer Tools app should not require 'System Developer' privilege

### DIFF
--- a/configuration/backend_configuration/privileges/privileges_core-demo.csv
+++ b/configuration/backend_configuration/privileges/privileges_core-demo.csv
@@ -33,3 +33,4 @@ dfc8b5f0-c736-4bc0-8f23-427f0d9c7e7f,Manage Cohort Definitions,Add/Edit/Remove C
 6b19d4ee-f6ae-4191-a60f-a70fcef5c461,Manage Scheduled Report Tasks,Manage Task Scheduling in Reporting Module,
 0a12b76e-2175-4eb7-af0b-498129ea1cac,Run Reports,Schedule the running of a report,
 a98c5b27-8d44-42b6-9b84-626cbcc5a227,Manage OrderTemplates,Base privilege for add/edit/delete order templates,
+37c728b8-3f55-4f38-9558-33484c6ead76,O3 Implementer Tools,Allows access to the O3 Implementer Tools features,


### PR DESCRIPTION
I added a new "O3 Implementer Tools" privilege in the OpenMRS system and assign it to the appropriate roles, ensuring that only authorized users can access the implementer tools features.