### PR TITLE
(chore): Bump openmrs maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 			<plugin>
 				<groupId>org.openmrs.maven.plugins</groupId>
 				<artifactId>openmrs-packager-maven-plugin</artifactId>
-				<version>1.9.0-SNAPSHOT</version>
+				<version>1.9.0</version>
 				<executions>
 					<execution>
 						<id>validate-content-package</id>


### PR DESCRIPTION
This PR bumps the Openmrs Packager Maven Plugin to 1.9.0