### PR TITLE
(fix) Add regex anchors to SSN identifier format validation

### DIFF
--- a/configuration/backend_configuration/patientidentifiertypes/patientidentifiertypes-core_demo.csv
+++ b/configuration/backend_configuration/patientidentifiertypes/patientidentifiertypes-core_demo.csv
@@ -2,4 +2,4 @@ Uuid,Void/Retire,Name,Description,Required,Format,Format description,Validator,L
 05a29f94-c0ed-11e2-94be-8c13b969e334,,OpenMRS ID,"OpenMRS patient identifier, with check-digit",TRUE,,,org.openmrs.module.idgen.validator.LuhnMod30IdentifierValidator,NOT_USED,UNIQUE
 22348099-3873-459e-a32e-d93b17eda533,,Legacy ID,Identifier type to record optional previous identifers ,FALSE,,,,NOT_USED,
 b4143563-16cd-4439-b288-f83d61670fc8,,ID Card,ID Card,FALSE,,,,NOT_USED,UNIQUE
-a71403f3-8584-4289-ab41-2b4e5570bd45,,SSN,Social Security Number,FALSE,[A-Z]{1}-[0-9]{7},"Identifier should be 1 letter, followed by a dash and 7 numerical characters. Eg, A-0010902",,NOT_USED,UNIQUE
+a71403f3-8584-4289-ab41-2b4e5570bd45,,SSN,Social Security Number,FALSE,^[A-Z]{1}-[0-9]{7}$,"Identifier must be exactly one uppercase letter, followed by a dash and exactly 7 digits. Example: A-0010902",,NOT_USED,UNIQUE


### PR DESCRIPTION
The previous regex for the SSN identifier was missing start (^) and end ($) anchors, allowing partial matches and permitting invalid formats such as extra characters (e.g., `X-A-1234567-Y`) or too many digits (e.g., `A-123456789`). This caused the validation to accept identifiers that did not exactly match the required format: one uppercase letter, a dash, and exactly seven digits (e.g., `A-0010902`).

This commit adds the necessary anchors to enforce strict matching and updates the regex description for clarity and accuracy, improving data quality by ensuring only valid identifiers are accepted.

Relates to: https://github.com/openmrs/openmrs-esm-patient-management/pull/1553