### PR TITLE
(fix): Update `Time of Procedure` concept to use `datetime` and add `datePickerFormat` to Surgical Operation form

### DIFF
--- a/configuration/backend_configuration/ampathforms/surgery-core_demo.json
+++ b/configuration/backend_configuration/ampathforms/surgery-core_demo.json
@@ -170,7 +170,7 @@
               "label": "Time of Procedure",
               "type": "obs",
               "questionOptions": {
-                "rendering": "date",
+                "rendering": "datetime",
                 "concept": "0934658e-fee3-44e3-a8f2-292dc3587f54",
                 "weeksList": ""
               },

--- a/configuration/backend_configuration/ampathforms/surgery-core_demo.json
+++ b/configuration/backend_configuration/ampathforms/surgery-core_demo.json
@@ -172,7 +172,8 @@
               "questionOptions": {
                 "rendering": "datetime",
                 "concept": "0934658e-fee3-44e3-a8f2-292dc3587f54",
-                "weeksList": ""
+                "weeksList": "",
+                "datePickerFormat": "both"
               },
               "id": "Time_of_Procedure"
             },

--- a/configuration/backend_configuration/ampathforms/surgery-core_demo.json
+++ b/configuration/backend_configuration/ampathforms/surgery-core_demo.json
@@ -172,9 +172,9 @@
               "questionOptions": {
                 "rendering": "datetime",
                 "concept": "0934658e-fee3-44e3-a8f2-292dc3587f54",
-                "weeksList": "",
-                "datePickerFormat": "both"
+                "weeksList": ""
               },
+              "datePickerFormat": "both",
               "id": "Time_of_Procedure"
             },
             {


### PR DESCRIPTION
This PR fixes a bug that prevents the Surgical Operation form from saving when the 'Time of Procedure' field is filled.