### PR TITLE
O3-5452: Added default configuration of encounter forms printing

### DIFF
--- a/configuration/backend_configuration/jsonkeyvalues/encounterPrinting.json
+++ b/configuration/backend_configuration/jsonkeyvalues/encounterPrinting.json
@@ -1,0 +1,18 @@
+{
+    "report.encounterPrinting.header.patientName": "true",
+    "report.encounterPrinting.header.location": "true",
+    "report.encounterPrinting.header.formName": "false",
+    "report.encounterPrinting.header.encounterDate": "true",
+    "report.encounterPrinting.header.visitStartDate": "false",
+    "report.encounterPrinting.header.visitEndDate": "false",
+    "report.encounterPrinting.header.visitType": "false",
+    "report.encounterPrinting.header.patientIdentifiers": "true",
+    "report.encounterPrinting.header.patientIdentifierTypes": "OpenMRS ID",
+    "report.encounterPrinting.header.personAttributes": "false",
+    "report.encounterPrinting.header.personAttributeTypes": "",
+    "report.encounterPrinting.header.visitAttributes": "false",
+    "report.encounterPrinting.header.visitAttributeTypes": "",
+    "report.encounterPrinting.footer.customText": "",
+    "report.encounterPrinting.stylesheet": "defaultEncounterFormFopStylesheet.xsl",
+    "report.encounterPrinting.logopath": ""
+}


### PR DESCRIPTION
Related ticket: https://openmrs.atlassian.net/browse/O3-5452

It contains default configuration of values displayed in encounter form pdf header. It includes patient name, patient location, encounter date and OpenMRS ID. It is just default configuration, it can be configured according to the implementer's preferences.