### PR TITLE
O3-5682: Add Visit Queue Number visit attribute type

### DIFF
--- a/configuration/backend_configuration/attributetypes/attribute_types-core_demo.csv
+++ b/configuration/backend_configuration/attributetypes/attribute_types-core_demo.csv
@@ -4,3 +4,4 @@ aac48226-d143-4274-80e0-264db4e368ee,,Visit,Insurance Policy Number,,0,1,org.ope
 3a988e33-a6c0-4b76-b924-01abb998944b,,Visit,Insurance Scheme,"The insurance scheme the patient is using to settle payment for services, expects a uuid",0,1,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,
 8553afa0-bdb9-4d3c-8a98-05fa9350aa85,,Visit,Payment Method,"The payment method used by the patient to settle payment, expects a uuid",0,1,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,
 fbc0702d-b4c9-4968-be63-af8ad3ad6239,,Visit,Patient Type,"If the patient will be paying or receives services for free, expects a uuid",0,1,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,
+c0c579b0-8e59-401d-8a4a-976a0b183519,,Visit,Visit Queue Number,The visit queue number used to identify patients on the queue screen,0,1,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,


### PR DESCRIPTION
## Summary
The Service Queues screen (`/spa/home/service-queues/screen`) is blank in default installs because the Call→serve flow depends on a "Visit Queue Number" visit attribute that nothing creates. `generateVisitQueueNumber` silently no-ops, visits never get a ticket number, and the assignticket POST 200s without storing anything.

Adds the `Visit Queue Number` VisitAttributeType (UUID `c0c579b0-8e59-401d-8a4a-976a0b183519`, FreeText) to the demo attribute-types content package so the initializer creates it on startup.

The UUID matches the `visitQueueNumberAttributeUuid` default set in the paired frontend PR [here](https://github.com/openmrs/openmrs-esm-patient-management/pull/2543).

## Related Issue
[O3-5682](https://openmrs.atlassian.net/browse/O3-5682)

### Related PR
https://github.com/openmrs/openmrs-module-queue/pull/113

[O3-5682]: https://openmrs.atlassian.net/browse/O3-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ